### PR TITLE
Pin Debian Bookworm for devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "Python Dev Container",
-    "image": "mcr.microsoft.com/devcontainers/python:3.10",
+    "image": "mcr.microsoft.com/devcontainers/python:3.10-bookworm",
     "features": {
       "ghcr.io/devcontainers/features/docker-in-docker:2": {}
     },


### PR DESCRIPTION
Debian 13 (Trixie) does not include packages for Moby, so the latest "mcr.microsoft.com/devcontainers/python:3.10" version does not work with the docker-in-docker feature.

To fix the problem, the bookworm version of the image is pinned in the devcontainer.

Thanks for your work @niclasheinz!

Signed-off-by: Aitor Iturrioz Rodríguez <aiturrioz@tknika.eus>