### PR TITLE
Update mkdocs-material to 9.6.20 version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-mkdocs-material==9.5.49
+mkdocs-material==9.6.20


### PR DESCRIPTION
Hi @niclasheinz!

I've seen that the live reload feature is not working and it seems to be a real issue with many mkdocs-material versions:

https://github.com/squidfunk/mkdocs-material/issues/8478

As a consequence, I have updated the library to the latest working version: 9.6.20.

Signed-off-by: Aitor Iturrioz Rodríguez <aiturrioz@tknika.eus>