### PR TITLE
devcontainer: use trixy-based python 3.13

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "Python Dev Container",
-    "image": "mcr.microsoft.com/devcontainers/python:3.10-bookworm",
+    "image": "mcr.microsoft.com/devcontainers/python:3.14",
     "customizations": {
       "vscode": {
         "settings": {


### PR DESCRIPTION
Bumping docker version to 3.13 (trixy)